### PR TITLE
no custom formatting

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -31,8 +31,8 @@ func NewNode(cs *CborIpldStore) *Node {
 }
 
 type KV struct {
-	Key   string
-	Value []byte
+	Key   string `refmt:"k,omitempty"`
+	Value []byte `refmt:"v,omitempty"`
 }
 
 type Pointer struct {

--- a/ipld.go
+++ b/ipld.go
@@ -27,18 +27,7 @@ func init() {
 	cbor.RegisterCborType(cbor.BigIntAtlasEntry)
 	cbor.RegisterCborType(Node{})
 	cbor.RegisterCborType(Pointer{})
-
-	kvAtlasEntry := atlas.BuildEntry(KV{}).Transform().TransformMarshal(
-		atlas.MakeMarshalTransformFunc(func(kv KV) ([]interface{}, error) {
-			return []interface{}{kv.Key, kv.Value}, nil
-		})).TransformUnmarshal(
-		atlas.MakeUnmarshalTransformFunc(func(v []interface{}) (KV, error) {
-			return KV{
-				Key:   v[0].(string),
-				Value: v[1].([]byte),
-			}, nil
-		})).Complete()
-	cbor.RegisterCborType(kvAtlasEntry)
+	cbor.RegisterCborType(KV{})
 }
 
 type CborIpldStore struct {


### PR DESCRIPTION
This also has #2 in it the only real change here is removing the custom refmt for KV pairs and just letting refmt do its thing. it adds a small amount of storage overhead but significantly increases speed.

Benchmarks using feature/serialization (#2) as before
Before:
```
 $ go test . -run ^TestSetGet -v -count=1
=== RUN   TestSetGet
Total size is: 7940530, size of keys+vals: 6600000, overhead: 1.20
&{4713 100000 map[1:41261 2:16450 3:8613]}
start flush
flush took:  174.85252ms
finds took:  875.937182ms
--- PASS: TestSetGet (3.75s)
PASS
ok  	github.com/quorumcontrol/go-hamt-ipld	3.778s
```

After:

```
$ go test . -run ^TestSetGet -v -count=1
=== RUN   TestSetGet
Total size is: 8340530, size of keys+vals: 6600000, overhead: 1.26
&{4713 100000 map[1:41261 2:16450 3:8613]}
start flush
flush took:  126.233134ms
finds took:  861.856529ms
--- PASS: TestSetGet (3.66s)
PASS
ok  	github.com/quorumcontrol/go-hamt-ipld	3.680s
```

And for community:

Before:
```
goos: darwin
goarch: amd64
pkg: github.com/quorumcontrol/community/hub/tupelocache
BenchmarkAddAddBlockRequest-12    	    3000	   1656344 ns/op	  858744 B/op	   10176 allocs/op
PASS
ok  	github.com/quorumcontrol/community/hub/tupelocache	7.180s
Success: Benchmarks passed.
```

After:
```
Running tool: /usr/local/bin/go test -benchmem -run=^$ github.com/quorumcontrol/community/hub/tupelocache -bench ^(BenchmarkAddAddBlockRequest)$

goos: darwin
goarch: amd64
pkg: github.com/quorumcontrol/community/hub/tupelocache
BenchmarkAddAddBlockRequest-12    	    5000	   1454983 ns/op	  760259 B/op	    9012 allocs/op
PASS
ok  	github.com/quorumcontrol/community/hub/tupelocache	10.773s
Success: Benchmarks passed.
```

