### PR TITLE
reduce pointer count from 256 to 128

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -76,7 +76,7 @@ func (n *Node) getValue(ctx context.Context, hv []byte, depth int, k string, cb 
 		return ErrMaxDepth
 	}
 
-	idx := hv[depth]
+	idx := int(hv[depth] / 2)
 	if n.Bitfield.Bit(int(idx)) == 0 {
 		return ErrNotFound
 	}
@@ -236,7 +236,7 @@ func (n *Node) modifyValue(ctx context.Context, hv []byte, depth int, k string, 
 	if depth >= len(hv) {
 		return ErrMaxDepth
 	}
-	idx := int(hv[depth])
+	idx := int(hv[depth] / 2)
 
 	if n.Bitfield.Bit(idx) != 1 {
 		return n.insertChild(idx, k, v)


### PR DESCRIPTION
This decreases the amount of time it takes to serialize a single node at the cost of more requests to do a find and an increased number of nodes to save when doing a flush. I think that's a tradeoff we're ok with but does require some thinking.

## Before

```
=== RUN   TestSetGet
Total size is: 8340530, size of keys+vals: 6600000, overhead: 1.26
&{4713 100000 map[1:41261 2:16450 3:8613]}
start flush
flush took:  131.97285ms
put of root node start
put of root node took:  929.263µs  pointer len:  256
finds took:  858.333089ms
```

```
goos: darwin
goarch: amd64
pkg: github.com/quorumcontrol/community/hub/tupelocache
BenchmarkAddAddBlockRequest-12    	    5000	   1545946 ns/op	  789502 B/op	   11567 allocs/op
PASS
ok  	github.com/quorumcontrol/community/hub/tupelocache	11.361s
Success: Benchmarks passed.
```

## After
```
=== RUN   TestSetGet
Total size is: 9016901, size of keys+vals: 6600000, overhead: 1.37
&{14184 100000 map[1:90006 2:2873 3:1416]}
start flush
flush took:  181.476745ms
put of root node start
put of root node took:  497.439µs  pointer len:  128
finds took:  1.123681161s
```

```
goos: darwin
goarch: amd64
pkg: github.com/quorumcontrol/community/hub/tupelocache
BenchmarkAddAddBlockRequest-12    	    5000	   1048806 ns/op	  575738 B/op	    8798 allocs/op
PASS
ok  	github.com/quorumcontrol/community/hub/tupelocache	8.828s
```
