### PR TITLE
upgrade refmt to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.0.2
 	github.com/ipfs/go-merkledag v0.1.0
 	github.com/multiformats/go-multihash v0.0.5
-	github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992
+	github.com/polydawn/refmt v0.0.0-20190807000000-3d65705ee9f12dc0dfcc0dc6cf9666e97b93f339
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992 h1:bzMe+2coZJYHnhGgVlcQKuRy4FSny4ds8dLQjw5P1XE=
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
+github.com/polydawn/refmt v0.0.0-20190807000000-3d65705ee9f12dc0dfcc0dc6cf9666e97b93f339 h1:zX5xrCBFjAVX9BNp0JR5NxcJxIZAO8d2IvHGdlMvxYQ=
+github.com/polydawn/refmt v0.0.0-20190807000000-3d65705ee9f12dc0dfcc0dc6cf9666e97b93f339/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa h1:E+gaaifzi2xF65PbDmuKI3PhLWY6G5opMLniFq8vmXA=


### PR DESCRIPTION
Given discussion here: https://github.com/polydawn/refmt/issues/51 this upgrades refmt. This particular fork of go-hamt-ipld relies *very little* on refmt now and so I didn't actually see any benchmark improvement here. 

I wanted to upgrade to check compatibility, etc so that if we bring it up to higher level repos (like community/tupelo) it is all using the same version in the tests.