### PR TITLE
simple ordering change, more intuition than reasoned thinking here

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -264,11 +264,11 @@ func (n *Node) Flush(ctx context.Context) error {
 					errChan <- err
 					return
 				}
+				p.SetLink(c)
 
 				p.cache = nil
 				// if p is a shard no need to keep the Kvs around
 				p.Kvs = nil
-				p.SetLink(c)
 			}(p)
 		}
 	}


### PR DESCRIPTION
I just had a thought that when the *reader* thread was coming down the node here, it might think that it needs to get the KV from here because the link isn't set, but then we had emptied them. This just changes the order to set the link and *then* remove the KVs.

I didn't really narrow the realworld stuff down to this, this more of a "I think this is better" than a "scientifically, this is a fix"